### PR TITLE
Make builds work on FreeBSD and OpenBSD (#58)

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -20,8 +20,8 @@ CFLAGS = @CFLAGS@ $(MYFLAGS) $(PROFILE)
 
 LIBS = @LIBS@ @CRYPTLIB@ @NETLIB@
 
-SRCFILES := $(wildcard *.c)
-OBJFILES := $(patsubst %.c,%.o,$(SRCFILES))  
+SRCFILES := act.comm.c act.informative.c act.item.c act.movement.c act.offensive.c act.other.c act.social.c act.wizard.c aedit.c asciimap.c ban.c boards.c bsd-snprintf.c castle.c cedit.c class.c comm.c config.c constants.c db.c dg_comm.c dg_db_scripts.c dg_event.c dg_handler.c dg_misc.c dg_mobcmd.c dg_objcmd.c dg_olc.c dg_scripts.c dg_triggers.c dg_variables.c dg_wldcmd.c fight.c genmob.c genobj.c genolc.c genqst.c genshp.c genwld.c genzon.c graph.c handler.c hedit.c house.c ibt.c improved-edit.c interpreter.c limits.c lists.c magic.c mail.c medit.c mobact.c modify.c msgedit.c mud_event.c oasis.c oasis_copy.c oasis_delete.c oasis_list.c objsave.c oedit.c players.c prefedit.c protocol.c qedit.c quest.c random.c redit.c sedit.c shop.c spec_assign.c spec_procs.c spell_parser.c spells.c tedit.c utils.c weather.c zedit.c zmalloc.c
+OBJFILES := act.comm.o act.informative.o act.item.o act.movement.o act.offensive.o act.other.o act.social.o act.wizard.o aedit.o asciimap.o ban.o boards.o bsd-snprintf.o castle.o cedit.o class.o comm.o config.o constants.o db.o dg_comm.o dg_db_scripts.o dg_event.o dg_handler.o dg_misc.o dg_mobcmd.o dg_objcmd.o dg_olc.o dg_scripts.o dg_triggers.o dg_variables.o dg_wldcmd.o fight.o genmob.o genobj.o genolc.o genqst.o genshp.o genwld.o genzon.o graph.o handler.o hedit.o house.o ibt.o improved-edit.o interpreter.o limits.o lists.o magic.o mail.o medit.o mobact.o modify.o msgedit.o mud_event.o oasis.o oasis_copy.o oasis_delete.o oasis_list.o objsave.o oedit.o players.o prefedit.o protocol.o qedit.o quest.o random.o redit.o sedit.o shop.o spec_assign.o spec_procs.o spell_parser.o spells.o tedit.o utils.o weather.o zedit.o zmalloc.o
 
 default: all
 

--- a/src/util/Makefile.in
+++ b/src/util/Makefile.in
@@ -23,16 +23,7 @@ CFLAGS = @CFLAGS@ $(MYFLAGS) $(PROFILE) -I$(INCDIR)
 
 default: all
 
-all: $(BINDIR)/asciipasswd \
-	$(BINDIR)/autowiz \
-	$(BINDIR)/plrtoascii \
-	$(BINDIR)/rebuildIndex \
-	$(BINDIR)/rebuildMailIndex \
-	$(BINDIR)/shopconv \
-	$(BINDIR)/sign \
-	$(BINDIR)/split \
-	$(BINDIR)/wld2html \
-	$(BINDIR)/webster 
+all: $(BINDIR)/asciipasswd $(BINDIR)/autowiz $(BINDIR)/plrtoascii $(BINDIR)/rebuildIndex $(BINDIR)/rebuildMailIndex $(BINDIR)/shopconv $(BINDIR)/sign $(BINDIR)/split $(BINDIR)/wld2html $(BINDIR)/webster
 
 asciipasswd: $(BINDIR)/asciipasswd
 


### PR DESCRIPTION
* make Makefile more portable

tbamud doesn't build on FreeBSD or OpenBSD.  This series of commits are meant to make those builds work by making the Makefile more portable.
I should mention that I've never used tbamud before today, so please read my pull request carefully.

This commit itself fixes the first issue encountered.  I assume wildcard and patsubst are gmake-only.

* Update Makefile.in

It turns out using the backslash to escape newlines in this situation is not portable.

* Delete Makefile.in

Will re-add.  There are problems with this file.  It's marked executable when it shouldn't be, and has ^M characters which prevent builds on OpenBSD.

* re-add Makefile.in